### PR TITLE
Allow access to payment intent and billing statement statement descriptor value

### DIFF
--- a/src/entities/BillingStatementEntity.js
+++ b/src/entities/BillingStatementEntity.js
@@ -14,6 +14,7 @@ function BillingStatementEntity(apiResource) {
   this.livemode = data.livemode;
   this.metadata = data.metadata;
   this.paymentIntent = data.payment_intent;
+  this.statementDescriptor = data.statement_descriptor;
   this.status = data.status;
   this.paymentSettings = data.payment_settings;
   this.customer = data.customer;

--- a/src/entities/PaymentIntentEntity.js
+++ b/src/entities/PaymentIntentEntity.js
@@ -14,6 +14,7 @@ function PaymentIntentEntity(apiResource) {
   this.paymentMethodId = data.payment_method_id;
   this.paymentMethods = data.payment_methods;
   this.paymentMethodOptions = data.payment_method_options;
+  this.statementDescriptor = data.statement_descriptor;
   this.status = data.status;
   this.nextAction = data.next_action;
   this.returnUrl = data.return_url;


### PR DESCRIPTION
## 🤔 What?
- Add `statementDescriptor` to payment intent and billing statement entities.

## 🤔 Why?
- To allow access to payment intent and billing statement statement descriptor value.

## 📝 Screenshots

https://github.com/user-attachments/assets/107ccdcd-4a93-4628-8f06-1f5a3ef41a95

