### PR TITLE
Support setup_future_usage on billing statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.7.1] - 2025-07-11
+
+- Support setup_future_usage on Billing Statement.
+
 ## [1.7.0] - 2025-06-24
 
 - Return billingStatementMerchantName in Billing Statement resource.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "payrex-node",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "payrex-node",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.8",
+        "payrex-node": "^1.7.0",
         "qs": "^6.12.1"
       },
       "devDependencies": {
@@ -1206,6 +1207,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/payrex-node": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/payrex-node/-/payrex-node-1.7.0.tgz",
+      "integrity": "sha512-hhVXPSOE59+jlJLLkzywfr5Tmy3wzxArwr6mANz32h2QwBsK0MFA09XDN7xgBWOCBtGQh3lyJkITdOVMK3UfTQ==",
+      "dependencies": {
+        "axios": "^1.6.8",
+        "qs": "^6.12.1"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payrex-node",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "PayRex Node JS Library",
   "keywords": [
     "payrex",
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "axios": "^1.6.8",
+    "payrex-node": "^1.7.0",
     "qs": "^6.12.1"
   },
   "license": "MIT",

--- a/src/entities/BillingStatementEntity.js
+++ b/src/entities/BillingStatementEntity.js
@@ -16,6 +16,7 @@ function BillingStatementEntity(apiResource) {
   this.livemode = data.livemode;
   this.metadata = data.metadata;
   this.paymentIntent = data.payment_intent;
+  this.setupFutureUsage = data.setup_future_usage;
   this.statementDescriptor = data.statement_descriptor;
   this.status = data.status;
   this.paymentSettings = data.payment_settings;


### PR DESCRIPTION
## 🤔 What?
- Support setup_future_usage on billing statement

## 🤔 Why?
- To support vaulting on billing statement.

## 📝 Additional Notes
<img width="491" height="607" alt="image" src="https://github.com/user-attachments/assets/43624e79-2025-42de-9478-1aa40d4c954e" />
